### PR TITLE
Allow multi-space for date parser and fix example typo for mark/unmark commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAttendanceCommand.java
@@ -29,11 +29,11 @@ public class MarkAttendanceCommand extends Command {
             + ": Mark the attendance of the person identified by the index number used in "
             + "the displayed person list and a datetime.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DATE + "DATETIME "
+            + PREFIX_DATE + "DATE_TIME "
             + PREFIX_ATTENDANCE + "ATTENDANCE \n"
             + "Example: \n"
-            + COMMAND_WORD + " 1" + PREFIX_DATE + "31/01/2024 12:00 " + PREFIX_ATTENDANCE + "Attended \n"
-            + COMMAND_WORD + " 1" + PREFIX_DATE + "31/01/2024 12:00 " + PREFIX_ATTENDANCE + "Absent \n";
+            + COMMAND_WORD + " 1 " + PREFIX_DATE + "31/01/2024 12:00 " + PREFIX_ATTENDANCE + "Attended \n"
+            + COMMAND_WORD + " 1 " + PREFIX_DATE + "31/01/2024 12:00 " + PREFIX_ATTENDANCE + "Absent \n";
 
     public static final String MESSAGE_MARK_ATTENDANCE_SUCCESS = "Person: %1$s marked as %2$s on %3$s";
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAttendanceCommand.java
@@ -27,9 +27,9 @@ public class UnmarkAttendanceCommand extends Command {
             + ": Remove an attendance record from the person identified by the index number "
             + "and a datetime.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_DATE + "DATETIME \n"
+            + PREFIX_DATE + "DATE_TIME \n"
             + "Example: \n"
-            + COMMAND_WORD + " 1" + PREFIX_DATE + "31/01/2024 12:00 \n";
+            + COMMAND_WORD + " 1 " + PREFIX_DATE + "31/01/2024 12:00 \n";
 
     public static final String MESSAGE_UNMARK_ATTENDANCE_SUCCESS = "Removed attendance for %1$s on %2$s";
     public static final String MESSAGE_ATTENDANCE_NOT_FOUND = "No attendance record on '%1$s'.";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -149,7 +149,7 @@ public class ParserUtil {
      */
     public static LocalDateTime parseDate(String date) throws ParseException {
         requireNonNull(date);
-        String trimmedDate = date.trim();
+        String trimmedDate = date.trim().replaceAll("  +", " ");
         DateTimeFormatter formatter = new DateTimeFormatterBuilder()
                 .appendPattern(AttendanceList.DATE_TIME_FORMAT)
                 .parseDefaulting(ChronoField.ERA, 1)


### PR DESCRIPTION
Fixes #95. Fixes #97. Fixes #141