### PR TITLE
Fix optional parameter syntax on aggGrade help message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AggGradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AggGradeCommand.java
@@ -26,7 +26,7 @@ public class AggGradeCommand extends Command {
                    "min", Operation.MIN, "stddev", Operation.STDDEV, "var", Operation.VAR));
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Performs aggregation operation the displayed "
             + "person list.\n"
-            + "Parameters: OPERATION " + PREFIX_NAME + "EXAM_NAME (optional)\n"
+            + "Parameters: OPERATION [" + PREFIX_NAME + "EXAM_NAME]\n"
             + "n/EXAM_NAME is optional. Inclusion of exam name will only perform aggregation on that specific exam\n"
             + "Operations can be: " + String.join(", ", OPERATION_TRANSLATE.keySet()) + "\n"
             + "example:\n" + "  aggGrade median\n" + "  aggGrade median n/midterm";


### PR DESCRIPTION
Closes #166 and #139

![image](https://github.com/user-attachments/assets/9dcd5688-30e8-43b1-a30a-5d9716994fd7)
-->
![image](https://github.com/user-attachments/assets/bfb757a8-1841-4401-af6d-f1ec4d1c3b95)
